### PR TITLE
Fix to not override body font settings.

### DIFF
--- a/packages/unit/README.md
+++ b/packages/unit/README.md
@@ -1227,11 +1227,10 @@ use settings of initialized font
 
 #### Parameters
 
-| Name                | Type                                                                                                                               | Description                          | Default    |
-| :------------------ | :--------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------- | :--------- |
-| `$feature-settings` | **[Boolean](https://sass-lang.com/documentation/values/booleans)**                                                                 | enable `font-eature-settings` or not | `false`    |
-| `$style`            | **[String](https://sass-lang.com/documentation/values/strings)**                                                                   | setting for `font-style`             | `"normal"` |
-| `$weight`           | **[String](https://sass-lang.com/documentation/values/strings)**, **[Number](https://sass-lang.com/documentation/values/numbers)** | setting for `font-weight`            | `"normal"` |
+| Name      | Type                                                                                                                               | Description               | Default    |
+| :-------- | :--------------------------------------------------------------------------------------------------------------------------------- | :------------------------ | :--------- |
+| `$style`  | **[String](https://sass-lang.com/documentation/values/strings)**                                                                   | setting for `font-style`  | `"normal"` |
+| `$weight` | **[String](https://sass-lang.com/documentation/values/strings)**, **[Number](https://sass-lang.com/documentation/values/numbers)** | setting for `font-weight` | `"normal"` |
 
 #### Examples
 
@@ -1247,8 +1246,6 @@ css outputs
 
 ```css
 .selector {
-  font-feature-settings: "palt";
-  -ms-font-feature-settings: normal;
   font-style: normal;
   font-weight: normal;
 }

--- a/packages/unit/README.md
+++ b/packages/unit/README.md
@@ -1182,6 +1182,40 @@ css outputs
 }
 ```
 
+<a id="features-mixin-use-font-advanced-settings"></a>
+
+### @mixin use-font-advanced-settings
+
+use advanced settings of font
+
++ **Group:** Features
++ **Access:** public
+
+#### Parameters
+
+| Name                | Type                                                             | Description                         | Default  |
+| :------------------ | :--------------------------------------------------------------- | :---------------------------------- | :------- |
+| `$feature-settings` | **[String](https://sass-lang.com/documentation/values/strings)** | setting for `font-feature-settings` | `"palt"` |
+
+#### Examples
+
+scss inputs
+
+```scss
+.selector {
+  @include use-font-advanced-settings();
+}
+```
+
+css outputs
+
+```css
+.selector {
+  font-feature-settings: "palt";
+  -ms-font-feature-settings: normal;
+}
+```
+
 <a id="features-mixin-use-font-base"></a>
 
 ### @mixin use-font-base

--- a/packages/unit/README.md
+++ b/packages/unit/README.md
@@ -241,6 +241,22 @@ enable override font settings or not.
 
 + **@mixin use-font-family** use settings of `font-family`
 
+<a id="default-settings-variable-unit-font-override-targets"></a>
+
+### $unit-font-override-targets
+
+target units that override font settings.
+(default: `"icon", "text", "pict", "button", "table", "document", "input", "toggle", "select")`)
+
+this use if `$unit-font-enable-override` is `true`
+
++ **Group:** Default settings
++ **Access:** public
+
+#### Type
+
+**[List](https://sass-lang.com/documentation/values/lists)**
+
 <a id="default-settings-variable-unit-font-family"></a>
 
 ### $unit-font-family

--- a/packages/unit/src/_override.scss
+++ b/packages/unit/src/_override.scss
@@ -1,14 +1,32 @@
-// setting base font-size for rem
+// override root font-size
 @if $unit-font-enable-relative-size {
   html {
     font-size: $unit-font-base-size;
   }
 }
 
-body {
-  @include use-font-family($value: "default");
+// override font-family and advanced settings
+@if $unit-font-enable-override {
+  $selector: unique-id();
 
-  // for mobile browser
-  // + https://caniuse.com/#search=text-size-adjust
-  text-size-adjust: 100%;
+  // define placeholder for override targets
+  @include define-placeholder($name: $selector) {
+    @include use-font-family($value: "default");
+
+    @if ($unit-font-enable-advanced-settings) {
+      @include use-font-advanced-settings();
+    }
+
+    // for mobile browser
+    // + https://caniuse.com/#search=text-size-adjust
+    text-size-adjust: 100%;
+  }
+
+  // override all targets
+  @each $target in $unit-font-override-targets {
+    [class^="#{$unit-prefix}-#{$target}"],
+    [class*=" #{$unit-prefix}-#{$target}"] {
+      @extend %#{$selector};
+    }
+  }
 }

--- a/packages/unit/src/_settings.scss
+++ b/packages/unit/src/_settings.scss
@@ -93,6 +93,24 @@ $unit-link-color: (
 ///
 $unit-font-enable-override: true !default;
 
+/// target units that override font settings.
+/// (default: `"icon", "text", "pict", "button", "table", "document", "input", "toggle", "select")`)
+///
+/// this use if `$unit-font-enable-override` is `true`
+/// @type List
+///
+$unit-font-override-targets: (
+  "icon",
+  "text",
+  "pict",
+  "button",
+  "table",
+  "document",
+  "input",
+  "toggle",
+  "select",
+) !default;
+
 /// default font family.
 ///
 /// **default**

--- a/packages/unit/src/lib/_mixin.scss
+++ b/packages/unit/src/lib/_mixin.scss
@@ -13,6 +13,7 @@
 @import "mixin/use-box-base";
 @import "mixin/use-clearfix";
 @import "mixin/use-font-base";
+@import "mixin/use-font-advanced-settings";
 @import "mixin/use-font-family";
 @import "mixin/use-font-size";
 @import "mixin/use-table-base";

--- a/packages/unit/src/lib/mixin/_use-font-advanced-settings.scss
+++ b/packages/unit/src/lib/mixin/_use-font-advanced-settings.scss
@@ -1,0 +1,27 @@
+////
+/// (c) hidoo | MIT Lisence
+/// @group features
+////
+
+/// use advanced settings of font
+/// @param {String} $feature-settings ["palt"] - setting for `font-feature-settings`
+///
+/// @example scss - scss inputs
+///   .selector {
+///     @include use-font-advanced-settings();
+///   }
+///
+/// @example css - css outputs
+///   .selector {
+///     font-feature-settings: "palt";
+///     -ms-font-feature-settings: normal;
+///   }
+///
+@mixin use-font-advanced-settings($feature-settings: "palt") {
+  @if type-of($feature-settings) == "string" and $feature-settings != "" {
+    font-feature-settings: $feature-settings;
+
+    // disable when browser is ie 10-11
+    -ms-font-feature-settings: normal; // stylelint-disable-line order/properties-order
+  }
+}

--- a/packages/unit/src/lib/mixin/_use-font-base.scss
+++ b/packages/unit/src/lib/mixin/_use-font-base.scss
@@ -4,7 +4,6 @@
 ////
 
 /// use settings of initialized font
-/// @param {Boolean} $feature-settings [false] - enable `font-eature-settings` or not
 /// @param {String} $style ["normal"] - setting for `font-style`
 /// @param {String|Number} $weight ["normal"] - setting for `font-weight`
 ///
@@ -15,30 +14,14 @@
 ///
 /// @example css - css outputs
 ///   .selector {
-///     font-feature-settings: "palt";
-///     -ms-font-feature-settings: normal;
 ///     font-style: normal;
 ///     font-weight: normal;
 ///   }
 ///
 @mixin use-font-base(
-  $feature-settings: false,
   $style: "normal",
   $weight: "normal"
 ) {
-  @if (
-    global-variable-exists("unit-font-enable-override") and
-    global-variable-exists("unit-font-enable-advanced-settings") and
-    $unit-font-enable-override and
-    $unit-font-enable-advanced-settings and
-    $feature-settings
-  ) {
-    font-feature-settings: "palt";
-
-    // disable when browser is ie 10-11
-    -ms-font-feature-settings: normal; // stylelint-disable-line order/properties-order
-  }
-
   @if type-of($style) == "string" and $style != "" {
     font-style: #{$style};
   }

--- a/packages/unit/src/lib/mixin/_use-font-family.scss
+++ b/packages/unit/src/lib/mixin/_use-font-family.scss
@@ -22,28 +22,26 @@
 ///   }
 ///
 @mixin use-font-family($value, $important: false) {
-  @if (
-    global-variable-exists("unit-font-enable-override") and
-    $unit-font-enable-override
-  ) {
-    @if type-of($value) == "list" and length($value) >= 1 {
-      font-family: $value if($important, !important, null);
+  @if type-of($value) == "list" and length($value) >= 1 {
+    font-family: $value if($important, !important, null);
+  }
+  @else if $value == "default" {
+    @if (global-variable-exists("unit-font-family")) {
+      font-family: $unit-font-family if($important, !important, null);
     }
-    @else if $value == "default" {
-      @if (global-variable-exists("unit-font-family")) {
-        font-family: $unit-font-family if($important, !important, null);
-      }
-      @else {
-        @error "@mixin use-font-family: Global variable $unit-font-family is undefined.";
-      }
+    @else {
+      @error "@mixin use-font-family: Global variable $unit-font-family is undefined.";
     }
-    @else if $value == "monospace" {
-      @if (global-variable-exists("unit-font-family-monospace")) {
-        font-family: $unit-font-family-monospace if($important, !important, null);
-      }
-      @else {
-        @error "@mixin use-font-family: Global variable $unit-font-family-monospace is undefined.";
-      }
+  }
+  @else if $value == "monospace" {
+    @if (global-variable-exists("unit-font-family-monospace")) {
+      font-family: $unit-font-family-monospace if($important, !important, null);
     }
+    @else {
+      @error "@mixin use-font-family: Global variable $unit-font-family-monospace is undefined.";
+    }
+  }
+  @else {
+    @warn "@mixin use-font-family: font-family is not set, bacause argument $value is not valid.";
   }
 }

--- a/packages/unit/src/unit/button/_core.scss
+++ b/packages/unit/src/unit/button/_core.scss
@@ -48,9 +48,7 @@ Style guide: #{$unit-prefix}-button.core.base
     $line-height: 1,
     $text-align: "center"
   );
-  @include use-font-base(
-    $feature-settings: true
-  );
+  @include use-font-base();
   @include use-font-size(
     $value: "medium"
   );

--- a/packages/unit/src/unit/document/_core.scss
+++ b/packages/unit/src/unit/document/_core.scss
@@ -291,9 +291,7 @@ Style guide: #{$unit-prefix}-document.core.base
   @include use-clearfix();
   @include use-box-base();
   @include use-text-base();
-  @include use-font-base(
-    $feature-settings: true
-  );
+  @include use-font-base();
   @include use-font-size(
     $value: "medium"
   );

--- a/packages/unit/src/unit/icon/_core.scss
+++ b/packages/unit/src/unit/icon/_core.scss
@@ -38,9 +38,7 @@ Style guide: #{$unit-prefix}-icon.core.base
   @include use-text-base(
     $text-indent: -100%
   );
-  @include use-font-base(
-    $feature-settings: true
-  );
+  @include use-font-base();
   @include use-font-size(
     $value: "medium"
   );

--- a/packages/unit/src/unit/input/_core.scss
+++ b/packages/unit/src/unit/input/_core.scss
@@ -49,9 +49,6 @@ Style guide: #{$unit-prefix}-input.core.base
   @include use-font-size(
     $value: "medium"
   );
-  @include use-font-family(
-    $value: "default"
-  );
 
   width: 100%;
   color: inherit;

--- a/packages/unit/src/unit/input/_core.scss
+++ b/packages/unit/src/unit/input/_core.scss
@@ -45,9 +45,7 @@ Style guide: #{$unit-prefix}-input.core.base
     $white-space: null,
     $word-wrap: null
   );
-  @include use-font-base(
-    $feature-settings: true
-  );
+  @include use-font-base();
   @include use-font-size(
     $value: "medium"
   );

--- a/packages/unit/src/unit/pict/_core.scss
+++ b/packages/unit/src/unit/pict/_core.scss
@@ -48,9 +48,7 @@ Style guide: #{$unit-prefix}-pict.core.base
     $letter-spacing: 0,
     $line-height: 0
   );
-  @include use-font-base(
-    $feature-settings: true
-  );
+  @include use-font-base();
   @include use-font-size(
     $value: "medium"
   );
@@ -66,9 +64,7 @@ Style guide: #{$unit-prefix}-pict.core.base
       $overflow: "hidden"
     );
     @include use-text-base();
-    @include use-font-base(
-      $feature-settings: true
-    );
+    @include use-font-base();
     @include use-font-size(
       $value: "medium"
     );

--- a/packages/unit/src/unit/select/_core.scss
+++ b/packages/unit/src/unit/select/_core.scss
@@ -66,9 +66,7 @@ Style guide: #{$unit-prefix}-select.core.base
       $white-space: null,
       $word-wrap: null
     );
-    @include use-font-base(
-      $feature-settings: true
-    );
+    @include use-font-base();
     @include use-font-size(
       $value: "medium"
     );

--- a/packages/unit/src/unit/table/_core.scss
+++ b/packages/unit/src/unit/table/_core.scss
@@ -59,9 +59,7 @@ Style guide: #{$unit-prefix}-table.core.builtin
       $padding: 5px 10px (5px * 1.5)
     );
     @include use-text-base();
-    @include use-font-base(
-      $feature-settings: true
-    );
+    @include use-font-base();
     @include use-font-size(
       $value: "medium"
     );

--- a/packages/unit/src/unit/text/_core.scss
+++ b/packages/unit/src/unit/text/_core.scss
@@ -35,9 +35,7 @@ Style guide: #{$unit-prefix}-text.core.base
 .#{$unit-prefix}-text {
   @include use-box-base();
   @include use-text-base();
-  @include use-font-base(
-    $feature-settings: true
-  );
+  @include use-font-base();
   @include use-font-size(
     $value: "medium"
   );

--- a/packages/unit/src/unit/toggle/_core.scss
+++ b/packages/unit/src/unit/toggle/_core.scss
@@ -80,9 +80,7 @@ Style guide: #{$unit-prefix}-toggle.core.base
     @include use-text-base(
       $text-indent: -100%
     );
-    @include use-font-base(
-      $feature-settings: true
-    );
+    @include use-font-base();
     @include use-font-size(
       $value: "medium"
     );

--- a/packages/unit/test/mixin/use-font-advanced-settings.test.js
+++ b/packages/unit/test/mixin/use-font-advanced-settings.test.js
@@ -1,0 +1,84 @@
+/* eslint max-len: 0, no-magic-numbers: 0 */
+
+import assert from 'assert';
+import {eachTestCases, normalizeGlobalSettings} from 'test-util';
+
+describe('@mixin use-font-advanced-settings(...)', () => {
+
+  /**
+   * wrapper
+   * @param {Object} options options
+   *   @param {String|Null} options.featureSettings setting for font-feature-settings
+   * @param {Object} globalSettings global settings
+   * @return {String}
+   */
+  function wrapper(options = {}, globalSettings = {}) {
+    const args = [
+      options.featureSettings || options.featureSettings === '' ? `$feature-settings: ${options.featureSettings}` : false
+    ];
+
+    return `
+${normalizeGlobalSettings(globalSettings)}
+@import "src/lib/mixin/use-font-advanced-settings";
+
+.selector {
+  @include use-font-advanced-settings(${args.filter((arg) => arg !== false).join(', ')});
+}
+    `;
+  }
+
+  it('should out default properties if arguments not set.', async () => {
+    const cases = [
+      {
+        params: [{}],
+        expected:
+/* eslint-disable indent */
+`.selector {
+  font-feature-settings: "palt";
+  -ms-font-feature-settings: normal;
+}`
+/* eslint-disable indent */
+      }
+    ];
+
+    await eachTestCases(cases, wrapper, ({error, result, expected}, {resolve, reject}) => {
+      if (error) {
+        return reject(error);
+      }
+
+      const actual = result.css.toString().trim();
+
+      assert(actual === expected);
+      return resolve();
+    }, {outputStyle: 'expanded'});
+  });
+
+  it('should out properties with specified value if arguments is set.', async () => {
+    const cases = [
+      {
+        params: [{
+          featureSettings: '"pkna"'
+        }],
+        expected:
+/* eslint-disable indent */
+`.selector {
+  font-feature-settings: "pkna";
+  -ms-font-feature-settings: normal;
+}`
+/* eslint-disable indent */
+      }
+    ];
+
+    await eachTestCases(cases, wrapper, ({error, result, expected}, {resolve, reject}) => {
+      if (error) {
+        return reject(error);
+      }
+
+      const actual = result.css.toString().trim();
+
+      assert(actual === expected);
+      return resolve();
+    }, {outputStyle: 'expanded'});
+  });
+
+});

--- a/packages/unit/test/mixin/use-font-base.test.js
+++ b/packages/unit/test/mixin/use-font-base.test.js
@@ -8,7 +8,6 @@ describe('@mixin use-font-base(...)', () => {
   /**
    * wrapper
    * @param {Object} options options
-   *   @param {String|Null} options.featureSettings enable font-eature-settings or not
    *   @param {String|Null} options.style setting for font-style
    *   @param {String|Null} options.weight setting for font-weight
    * @param {Object} globalSettings global settings
@@ -16,7 +15,6 @@ describe('@mixin use-font-base(...)', () => {
    */
   function wrapper(options = {}, globalSettings = {}) {
     const args = [
-      options.featureSettings || options.featureSettings === '' ? `$feature-settings: ${options.featureSettings}` : false,
       options.style || options.style === '' ? `$style: ${options.style}` : false,
       options.weight || options.weight === '' ? `$weight: ${options.weight}` : false
     ];
@@ -31,62 +29,6 @@ ${normalizeGlobalSettings(globalSettings)}
     `;
   }
 
-  it('should not out font-feature-settings if corresponding global variable is not true.', async () => {
-    const cases = [
-      {
-        params: [{}, {fontEnableOverride: null}],
-        expected:
-/* eslint-disable indent */
-`.selector {
-  font-style: normal;
-  font-weight: normal;
-}`
-/* eslint-disable indent */
-      },
-      {
-        params: [{}, {fontEnableOverride: 'false'}],
-        expected:
-/* eslint-disable indent */
-`.selector {
-  font-style: normal;
-  font-weight: normal;
-}`
-/* eslint-disable indent */
-      },
-      {
-        params: [{}, {fontEnableAdvancedSettings: null}],
-        expected:
-/* eslint-disable indent */
-`.selector {
-  font-style: normal;
-  font-weight: normal;
-}`
-/* eslint-disable indent */
-      },
-      {
-        params: [{}, {fontEnableAdvancedSettings: 'false'}],
-        expected:
-/* eslint-disable indent */
-`.selector {
-  font-style: normal;
-  font-weight: normal;
-}`
-/* eslint-disable indent */
-      }
-    ];
-
-    await eachTestCases(cases, wrapper, ({error, result, expected}, {resolve, reject}) => {
-      if (error) {
-        return reject(error);
-      }
-
-      const actual = result.css.toString().trim();
-
-      assert(actual === expected);
-      return resolve();
-    }, {outputStyle: 'expanded'});
-  });
-
   it('should out default properties if arguments not set.', async () => {
     const cases = [
       {
@@ -94,34 +36,6 @@ ${normalizeGlobalSettings(globalSettings)}
         expected:
 /* eslint-disable indent */
 `.selector {
-  font-style: normal;
-  font-weight: normal;
-}`
-/* eslint-disable indent */
-      }
-    ];
-
-    await eachTestCases(cases, wrapper, ({error, result, expected}, {resolve, reject}) => {
-      if (error) {
-        return reject(error);
-      }
-
-      const actual = result.css.toString().trim();
-
-      assert(actual === expected);
-      return resolve();
-    }, {outputStyle: 'expanded'});
-  });
-
-  it('should out properties with font-feature-settings if arguments $feature-settings is true.', async () => {
-    const cases = [
-      {
-        params: [{featureSettings: 'true'}],
-        expected:
-/* eslint-disable indent */
-`.selector {
-  font-feature-settings: "palt";
-  -ms-font-feature-settings: normal;
   font-style: normal;
   font-weight: normal;
 }`

--- a/packages/unit/test/mixin/use-font-family.test.js
+++ b/packages/unit/test/mixin/use-font-family.test.js
@@ -51,26 +51,6 @@ ${normalizeGlobalSettings(globalSettings)}
     });
   });
 
-  it('should not out if global variable $unit-font-enable-override is not true.', async () => {
-    const cases = [
-      {
-        params: [{value: '(serif,)'}, {fontEnableOverride: null}],
-        expected: ''
-      }
-    ];
-
-    await eachTestCases(cases, wrapper, ({error, result, expected}, {resolve, reject}) => {
-      if (error) {
-        return reject(error);
-      }
-
-      const actual = result.css.toString().trim();
-
-      assert(actual === expected);
-      return resolve();
-    });
-  });
-
   it('should out font-family.', async () => {
     const cases = [
       {


### PR DESCRIPTION
before:

```css
body {
  font-family: -apple-system, BlinkMacSystemFont, Helvetica, Arial, "Hiragino Kaku Gothic ProN", "Yu Gothic Medium", "游ゴシック Medium", YuGothic, Meiryo, "メイリオ", sans-serif;
  -webkit-text-size-adjust: 100%;
      -ms-text-size-adjust: 100%;
          text-size-adjust: 100%;
}
```

after:

```css
[class^="unit-icon"],
[class*=" unit-icon"], [class^="unit-text"],
[class*=" unit-text"], [class^="unit-pict"],
[class*=" unit-pict"], [class^="unit-button"],
[class*=" unit-button"], [class^="unit-table"],
[class*=" unit-table"], [class^="unit-document"],
[class*=" unit-document"], [class^="unit-input"],
[class*=" unit-input"], [class^="unit-toggle"],
[class*=" unit-toggle"], [class^="unit-select"],
[class*=" unit-select"] {
  font-family: -apple-system, BlinkMacSystemFont, Helvetica, Arial, "Hiragino Kaku Gothic ProN", "Yu Gothic Medium", "游ゴシック Medium", YuGothic, Meiryo, "メイリオ", sans-serif;
  -webkit-font-feature-settings: "palt";
          font-feature-settings: "palt";
  -ms-font-feature-settings: normal;
  -webkit-text-size-adjust: 100%;
      -ms-text-size-adjust: 100%;
          text-size-adjust: 100%;
}
```